### PR TITLE
Add Stack property to BarChartDataset and LineChartDataset

### DIFF
--- a/BlazorExpress.ChartJS/Models/ChartDataset/BarChart/BarChartDataset.cs
+++ b/BlazorExpress.ChartJS/Models/ChartDataset/BarChart/BarChartDataset.cs
@@ -275,8 +275,20 @@ public class BarChartDataset : ChartDataset<double?>
     [Description("If <b>true</b>, null or undefined values will not be used for spacing calculations when determining bar size.")]
     public bool SkipNull { get; set; }
 
-    //Stack
-    //https://www.chartjs.org/docs/latest/charts/bar.html#general
+    /// <summary>
+    /// The ID of the group to which this dataset belongs. Datasets sharing the same
+    /// stack are stacked together; datasets with different stacks render side by side.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// <see href="https://www.chartjs.org/docs/latest/charts/bar.html#general" />
+    /// </summary>
+    [AddedVersion("1.2.3")]
+    [DefaultValue(null)]
+    [Description("The ID of the group to which this dataset belongs. Datasets sharing the same stack are stacked together; datasets with different stacks render side by side.")]
+    [ParameterTypeName("string?")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Stack { get; set; }
 
     /// <summary>
     /// The ID of the x-axis to plot this dataset on.

--- a/BlazorExpress.ChartJS/Models/ChartDataset/LineChart/LineChartDataset.cs
+++ b/BlazorExpress.ChartJS/Models/ChartDataset/LineChart/LineChartDataset.cs
@@ -563,8 +563,21 @@ public class LineChartDataset : ChartDataset<double?>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? SpanGaps { get; set; }
 
-    //stack
-    //https://www.chartjs.org/docs/latest/charts/line.html#general
+    /// <summary>
+    /// The ID of the group to which this dataset belongs. On a stacked scale,
+    /// datasets sharing the same stack are stacked together; datasets with
+    /// different stacks are drawn independently.
+    /// <para>
+    /// Default value is <see langword="null" />.
+    /// </para>
+    /// <see href="https://www.chartjs.org/docs/latest/charts/line.html#general" />
+    /// </summary>
+    [AddedVersion("1.2.3")]
+    [DefaultValue(null)]
+    [Description("The ID of the group to which this dataset belongs. Datasets sharing the same stack are stacked together; datasets with different stacks are drawn independently.")]
+    [ParameterTypeName("string?")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Stack { get; set; }
 
     /// <summary>
     /// If the stepped value is set to anything other than <see langword="false"/>, tension will be ignored.


### PR DESCRIPTION
## Summary
Implements the `stack` dataset property for `BarChartDataset` and
`LineChartDataset` — both files already carry a `//stack` placeholder.

`stack` is a standard Chart.js dataset option. On a stacked scale,
datasets sharing the same `stack` id are combined; datasets with
different ids render independently. This enables the documented
"Stacked Bar with Groups" chart, currently not expressible via the wrapper.

## Changes
- `BarChartDataset`: new `string? Stack` (replaces the `//Stack` placeholder)
- `LineChartDataset`: new `string? Stack` (replaces the `//stack` placeholder)

Both follow the existing property pattern (`[AddedVersion]`,
`[DefaultValue(null)]`, `[Description]`, `[ParameterTypeName]`,
`[JsonIgnore(WhenWritingNull)]`). Purely additive — no behaviour change,
omitted from JSON when null.

`[AddedVersion("1.2.3")]` is a placeholder — happy to adjust to whatever
the next release version should be.