### PR TITLE
Update BarChart and LineChart demos to enhance documentation and add stacked line chart example

### DIFF
--- a/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/BarChart/BarChartDocumentation.razor
+++ b/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/BarChart/BarChartDocumentation.razor
@@ -105,12 +105,14 @@
         The <strong>Stacked Bar Chart with Data Labels</strong> enhances the standard stacked bar chart by displaying value labels directly on each bar segment. This makes it easier to read and compare the values of each dataset within a category.
         <br /><br />
         <strong>How to use:</strong>
-        <ul>
-            <li>Use the <code>BarChart</code> component and enable stacking by setting <code>Options.Scales.X.Stacked</code> and <code>Options.Scales.Y.Stacked</code> to <code>true</code>.</li>
-            <li>Add multiple datasets to your chart data to represent different series.</li>
-            <li>Enable data labels by configuring the chart's plugins, such as <code>Options.Plugins.Datalabels.Display = true</code>.</li>
-            <li>Customize the appearance and formatting of data labels as needed for your scenario.</li>
-        </ul>
+        <div class="content">
+            <ol>
+                <li>Use the <code>BarChart</code> component and enable stacking by setting <code>Options.Scales.X.Stacked</code> and <code>Options.Scales.Y.Stacked</code> to <code>true</code>.</li>
+                <li>Add multiple datasets to your chart data to represent different series.</li>
+                <li>Enable data labels by passing the <code>ChartDataLabels</code> plugin when calling <code>InitializeAsync</code>: <code>plugins: new[] { "ChartDataLabels" }</code>.</li>
+                <li>Customize label styling with <code>Options.Plugins.Datalabels</code> or per-dataset <code>Datalabels</code> settings as needed.</li>
+            </ol>
+        </div>
         Refer to the demo code below for a working example and further configuration options.
     </Block>
     <Demo Type="typeof(BarChart_Demo_04_Stacked_BarChart_with_Datalabels)" Tabs="true" />
@@ -170,7 +172,7 @@
     <Demo Type="typeof(BarChart_Demo_07_Animations_A_Delay)" Tabs="true" />
 </Section>
 
-<Section Class="p-0" Size="HeadingSize.H4" Name="Animations - DataSet level delay" PageUrl="@pageUrl" Link="animations-dataset-level-delay">
+<Section Class="p-0" Size="HeadingSize.H4" Name="Animations - Dataset level delay" PageUrl="@pageUrl" Link="animations-dataset-level-delay">
     <Block>
         The <strong>Animations - DataSet Level Delay</strong> demo demonstrates how to apply different animation delays to each dataset in your Bar Chart. This allows each dataset to animate in sequence, making comparisons clearer and adding a dynamic effect to your data presentation.
         <br /><br />

--- a/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/BarChart/BarChart_Demo_03_Stacked_BarChart.razor
+++ b/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/BarChart/BarChart_Demo_03_Stacked_BarChart.razor
@@ -9,45 +9,44 @@
     {
         var colors = ColorUtility.CategoricalTwelveColors;
 
-        var labels = new List<string> { "Chrome", "Firefox", "Safari", "Edge" };
-        var datasets = new List<IChartDataset>();
-
-        var dataset1 = new BarChartDataset()
+        chartData = new ChartData
         {
-            Label = "Windows",
-            Data = new List<double?> { 28000, 8000, 2000, 17000 },
-            BackgroundColor = new List<string> { colors[0] },
-            BorderColor = new List<string> { colors[0] },
-            BorderWidth = new List<double> { 0 },
+            Labels = new List<string> { "Chrome", "Firefox", "Safari", "Edge" },
+            Datasets = new List<IChartDataset>
+            {
+                new BarChartDataset
+                {
+                    Label = "Windows",
+                    Data = new List<double?> { 28000, 8000, 2000, 17000 },
+                    BackgroundColor = new List<string> { colors[0] },
+                    BorderColor = new List<string> { colors[0] },
+                    BorderWidth = new List<double> { 0 },
+                },
+                new BarChartDataset
+                {
+                    Label = "macOS",
+                    Data = new List<double?> { 8000, 10000, 14000, 8000 },
+                    BackgroundColor = new List<string> { colors[1] },
+                    BorderColor = new List<string> { colors[1] },
+                    BorderWidth = new List<double> { 0 },
+                },
+                new BarChartDataset
+                {
+                    Label = "Other",
+                    Data = new List<double?> { 28000, 10000, 14000, 8000 },
+                    BackgroundColor = new List<string> { colors[2] },
+                    BorderColor = new List<string> { colors[2] },
+                    BorderWidth = new List<double> { 0 },
+                },
+            },
         };
-        datasets.Add(dataset1);
 
-        var dataset2 = new BarChartDataset()
+        barChartOptions = new BarChartOptions
         {
-            Label = "macOS",
-            Data = new List<double?> { 8000, 10000, 14000, 8000 },
-            BackgroundColor = new List<string> { colors[1] },
-            BorderColor = new List<string> { colors[1] },
-            BorderWidth = new List<double> { 0 },
+            Responsive = true,
+            Interaction = new Interaction { Mode = InteractionMode.Y },
+            IndexAxis = "y",
         };
-        datasets.Add(dataset2);
-
-        var dataset3 = new BarChartDataset()
-        {
-            Label = "Other",
-            Data = new List<double?> { 28000, 10000, 14000, 8000 },
-            BackgroundColor = new List<string> { colors[2] },
-            BorderColor = new List<string> { colors[2] },
-            BorderWidth = new List<double> { 0 },
-        };
-        datasets.Add(dataset3);
-
-        chartData = new ChartData { Labels = labels, Datasets = datasets };
-
-        barChartOptions = new();
-        barChartOptions.Responsive = true;
-        barChartOptions.Interaction = new Interaction { Mode = InteractionMode.Y };
-        barChartOptions.IndexAxis = "y";
 
         barChartOptions.Scales.X!.Title = new ChartAxesTitle { Text = "Visitors", Display = true };
         barChartOptions.Scales.Y!.Title = new ChartAxesTitle { Text = "Browser", Display = true };
@@ -62,9 +61,8 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
-        {
             await barChart.InitializeAsync(chartData, barChartOptions);
-        }
+
         await base.OnAfterRenderAsync(firstRender);
     }
 }

--- a/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/BarChart/BarChart_Demo_04_Stacked_BarChart_with_Datalabels.razor
+++ b/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/BarChart/BarChart_Demo_04_Stacked_BarChart_with_Datalabels.razor
@@ -8,50 +8,44 @@
     protected override void OnInitialized()
     {
         var colors = ColorUtility.CategoricalTwelveColors;
-
-        var labels = new List<string> { "Chrome", "Firefox", "Safari", "Edge" };
-        var datasets = new List<IChartDataset>();
-
-        var dataset1 = new BarChartDataset()
-        {
-            Label = "Windows",
-            Data = new List<double?> { 28000, 8000, 2000, 17000 },
-            BackgroundColor = new List<string> { colors[0] },
-            BorderColor = new List<string> { colors[0] },
-            BorderWidth = new List<double> { 0 },
-        };
-        datasets.Add(dataset1);
-
-        var dataset2 = new BarChartDataset()
-        {
-            Label = "macOS",
-            Data = new List<double?> { 8000, 10000, 14000, 8000 },
-            BackgroundColor = new List<string> { colors[1] },
-            BorderColor = new List<string> { colors[1] },
-            BorderWidth = new List<double> { 0 },
-        };
-        datasets.Add(dataset2);
-
-        var dataset3 = new BarChartDataset()
-        {
-            Label = "Other",
-            Data = new List<double?> { 28000, 10000, 14000, 8000 },
-            BackgroundColor = new List<string> { colors[2] },
-            BorderColor = new List<string> { colors[2] },
-            BorderWidth = new List<double> { 0 },
-        };
-        datasets.Add(dataset3);
-
         chartData = new ChartData
         {
-            Labels = labels,
-            Datasets = datasets
+            Labels = new List<string> { "Chrome", "Firefox", "Safari", "Edge" },
+            Datasets = new List<IChartDataset>
+            {
+                new BarChartDataset
+                {
+                    Label = "Windows",
+                    Data = new List<double?> { 28000, 8000, 2000, 17000 },
+                    BackgroundColor = new List<string> { colors[0] },
+                    BorderColor = new List<string> { colors[0] },
+                    BorderWidth = new List<double> { 0 },
+                },
+                new BarChartDataset
+                {
+                    Label = "macOS",
+                    Data = new List<double?> { 8000, 10000, 14000, 8000 },
+                    BackgroundColor = new List<string> { colors[1] },
+                    BorderColor = new List<string> { colors[1] },
+                    BorderWidth = new List<double> { 0 },
+                },
+                new BarChartDataset
+                {
+                    Label = "Other",
+                    Data = new List<double?> { 28000, 10000, 14000, 8000 },
+                    BackgroundColor = new List<string> { colors[2] },
+                    BorderColor = new List<string> { colors[2] },
+                    BorderWidth = new List<double> { 0 },
+                },
+            },
         };
 
-        barChartOptions = new();
-        barChartOptions.Responsive = true;
-        barChartOptions.Interaction = new Interaction { Mode = InteractionMode.Y };
-        barChartOptions.IndexAxis = "y";
+        barChartOptions = new BarChartOptions
+        {
+            Responsive = true,
+            Interaction = new Interaction { Mode = InteractionMode.Y },
+            IndexAxis = "y",
+        };
 
         barChartOptions.Scales.X!.Title = new ChartAxesTitle { Text = "Visitors", Display = true };
         barChartOptions.Scales.Y!.Title = new ChartAxesTitle { Text = "Browser", Display = true };
@@ -61,15 +55,14 @@
 
         barChartOptions.Plugins.Title!.Text = "Operating system";
         barChartOptions.Plugins.Title.Display = true;
+        barChartOptions.Plugins.Datalabels.Color = "white";
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
-        {
-            // pass the plugin name to enable the data labels
             await barChart.InitializeAsync(chartData: chartData, chartOptions: barChartOptions, plugins: new string[] { "ChartDataLabels" });
-        }
+
         await base.OnAfterRenderAsync(firstRender);
     }
 }

--- a/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/LineChart/LineChartDocumentation.razor
+++ b/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/LineChart/LineChartDocumentation.razor
@@ -54,6 +54,23 @@
     <Demo Type="typeof(LineChart_Demo_06_Combo_Bar_Line)" Tabs="true" />
 </Section>
 
+<Section Class="p-0" Size="HeadingSize.H4" Name="Stacked line chart" PageUrl="@pageUrl" Link="stacked-line-chart">
+    <Block>
+        The <strong>Stack</strong> demo shows how to combine <code>LineChartDataset.Stack</code> with a stacked Y-axis to build a layered line or area chart.
+        <br /><br />
+        <strong>How to use:</strong>
+        <div class="content">
+            <ol>
+                <li>Set <code>Options.Scales.Y.Stacked = true</code> so values accumulate on the Y-axis.</li>
+                <li>Assign the same <code>Stack</code> value to each <code>LineChartDataset</code> that should contribute to the same stacked total.</li>
+                <li>Optionally set <code>Fill</code> or use <code>FillToStackedValueBelow()</code> to make each layer easier to read.</li>
+                <li>Refer to the demo code below for a working example of stacked traffic series using shared stack IDs.</li>
+            </ol>
+        </div>
+    </Block>
+    <Demo Type="typeof(LineChart_Demo_07_Stack)" Tabs="true" />
+</Section>
+
 <Section Class="p-0" Size="HeadingSize.H4" Name="Data labels" PageUrl="@pageUrl" Link="data-labels">
     <Block>
         The <strong>Line Chart</strong> component supports data labels, allowing you to display values directly on each data point in the chart.
@@ -61,8 +78,8 @@
         <strong>How to use:</strong>
         <div class="content">
             <ol>
-                <li>Enable data labels by setting <code>Options.Plugins.Datalabels.Display = true</code> in your chart options.</li>
-                <li>Customize the label content, formatting, and position using the available plugin settings.</li>
+                <li>Enable data labels by passing the <code>ChartDataLabels</code> plugin when calling <code>InitializeAsync</code>: <code>plugins: new[] { "ChartDataLabels" }</code>.</li>
+                <li>Customize the label content, formatting, and position using <code>Options.Plugins.Datalabels</code> or per-dataset <code>Datalabels</code> settings.</li>
                 <li>Bind your data and labels to the chart as usual.</li>
                 <li>Refer to the demo code below for a working example and further configuration options.</li>
             </ol>
@@ -72,7 +89,7 @@
     <Demo Type="typeof(LineChart_Demo_02_Datalabels)" Tabs="true" />
 </Section>
 
-<Section Class="p-0" Size="HeadingSize.H4" Name="Tick Configuration" PageUrl="@pageUrl" Link="tick-configuration">
+<Section Class="p-0" Size="HeadingSize.H4" Name="Tick configuration" PageUrl="@pageUrl" Link="tick-configuration">
     <Block>
         The <strong>Tick Configuration</strong> demo shows how to customize the appearance and behavior of axis ticks in the Line Chart component.
         <br /><br />

--- a/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/LineChart/LineChart_Demo_07_Stack.razor
+++ b/BlazorExpress.ChartJS.Demo.RCL/Pages/Demos/LineChart/LineChart_Demo_07_Stack.razor
@@ -1,0 +1,81 @@
+<LineChart @ref="lineChart" Width="700" />
+
+@code {
+    private const string TrafficStack = "traffic";
+
+    private LineChart lineChart = default!;
+    private LineChartOptions lineChartOptions = default!;
+    private ChartData chartData = default!;
+
+    protected override void OnInitialized()
+    {
+        var desktopColor = ColorUtility.CategoricalTwelveColors[0].ToColor();
+        var mobileColor = ColorUtility.CategoricalTwelveColors[1].ToColor();
+        var tabletColor = ColorUtility.CategoricalTwelveColors[2].ToColor();
+
+        chartData = new ChartData
+        {
+            Labels = new List<string> { "January", "February", "March", "April", "May", "June" },
+            Datasets = new List<IChartDataset>
+            {
+                new LineChartDataset
+                {
+                    Label = "Desktop",
+                    Stack = TrafficStack,
+                    Data = new List<double?> { 35, 38, 42, 46, 50, 53 },
+                    BackgroundColor = desktopColor.ToRgbaString(0.35),
+                    BorderColor = desktopColor.ToRgbString(),
+                    BorderWidth = 2,
+                    PointRadius = new List<double> { 3 },
+                    PointHoverRadius = new List<double> { 5 },
+                    Tension = 0.35,
+                }.FillToOrigin(),
+                new LineChartDataset
+                {
+                    Label = "Mobile",
+                    Stack = TrafficStack,
+                    Data = new List<double?> { 22, 25, 29, 33, 36, 40 },
+                    BackgroundColor = mobileColor.ToRgbaString(0.35),
+                    BorderColor = mobileColor.ToRgbString(),
+                    BorderWidth = 2,
+                    PointRadius = new List<double> { 3 },
+                    PointHoverRadius = new List<double> { 5 },
+                    Tension = 0.35,
+                }.FillToStackedValueBelow(),
+                new LineChartDataset
+                {
+                    Label = "Tablet",
+                    Stack = TrafficStack,
+                    Data = new List<double?> { 10, 12, 13, 15, 16, 18 },
+                    BackgroundColor = tabletColor.ToRgbaString(0.35),
+                    BorderColor = tabletColor.ToRgbString(),
+                    BorderWidth = 2,
+                    PointRadius = new List<double> { 3 },
+                    PointHoverRadius = new List<double> { 5 },
+                    Tension = 0.35,
+                }.FillToStackedValueBelow(),
+            },
+        };
+
+        lineChartOptions = new LineChartOptions
+        {
+            Responsive = true,
+            Interaction = new Interaction { Mode = InteractionMode.Index, Intersect = false },
+        };
+
+        lineChartOptions.Scales.X!.Title = new ChartAxesTitle { Text = "Month", Display = true };
+        lineChartOptions.Scales.Y!.Title = new ChartAxesTitle { Text = "Sessions", Display = true };
+        lineChartOptions.Scales.Y.Stacked = true;
+
+        lineChartOptions.Plugins.Title!.Text = "Website sessions by device type";
+        lineChartOptions.Plugins.Title.Display = true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            await lineChart.InitializeAsync(chartData, lineChartOptions);
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+}


### PR DESCRIPTION
This pull request improves the Bar and Line Chart demo documentation and code samples to provide clearer, more consistent guidance on advanced features like stacking, data labels, and plugin usage. It also introduces a new stacked line chart example and streamlines the initialization of chart data and options in the demo components.

**Documentation improvements:**

* Updated the Bar Chart and Line Chart documentation to clarify how to enable and customize data labels, now recommending passing the `ChartDataLabels` plugin via the `InitializeAsync` method and providing more precise customization instructions. 
* Added a new "Stacked line chart" section to the Line Chart documentation, explaining how to use the `Stack` property and stacked Y-axis for layered line/area charts, with step-by-step usage instructions.
* Improved section titles for consistency (e.g., "Tick configuration" instead of "Tick Configuration", and "Dataset level delay" instead of "DataSet level delay").

**Demo code enhancements:**

* Refactored the Bar Chart and Stacked Bar Chart with Data Labels demo components to initialize `ChartData` and `BarChartOptions` in a more concise and idiomatic way, reducing boilerplate and improving readability.
* Ensured that the correct plugin enabling and option customization for data labels are demonstrated, including setting label color and passing the plugin name during initialization.

**New example:**

* Added a new `LineChart_Demo_07_Stack.razor` demo that showcases a stacked line/area chart using the `Stack` property and stacked Y-axis, with multiple datasets representing device types.